### PR TITLE
Rework base API for fuzzer

### DIFF
--- a/lib/fuzz.ak
+++ b/lib/fuzz.ak
@@ -1,0 +1,122 @@
+use aiken/builtin
+use aiken/bytearray
+use aiken/math.{pow2}
+
+// Primitives
+
+pub type Seed {
+  seed: Int,
+  size: Int,
+}
+
+type Fuzzer<a> =
+  fn(Seed) -> (Seed, a)
+
+///
+pub fn constant(a: a) -> Fuzzer<a> {
+  fn(seed) { (seed, a) }
+}
+
+///
+pub fn map(f: fn(a) -> b, fuzz_a: Fuzzer<a>) -> Fuzzer<b> {
+  fn(s0) {
+    let (s1, a) = fuzz_a(s0)
+    (s1, f(a))
+  }
+}
+
+pub fn and_map(fuzz_f: Fuzzer<fn(a) -> b>, fuzz_a: Fuzzer<a>) -> Fuzzer<b> {
+  fn(s0) {
+    let (s1, f) = fuzz_f(s0)
+    let (s2, a) = fuzz_a(s1)
+    (s2, f(a))
+  }
+}
+
+pub fn and_then(f: fn(a) -> Fuzzer<b>, fuzz_a: Fuzzer<a>) -> Fuzzer<b> {
+  fn(s0) {
+    let (s1, a) = fuzz_a(s0)
+    f(a)(s1)
+  }
+}
+
+/// Generate int values within [-2^32; 2^32 - 1]
+pub fn int() -> Fuzzer<Int> {
+  fn(s: Seed) {
+    let sign = s.seed % 2 == 0
+    let val = bytearray_to_int(builtin.blake2b_256(int_to_bytearray(s.seed)))
+    (
+      step_seed(s),
+      if sign {
+        val
+      } else {
+        -val - 1
+      },
+    )
+  }
+}
+
+/// Generate bytearrays of 32 bytes
+pub fn bytearray() -> Fuzzer<ByteArray> {
+  fn(s: Seed) { (step_seed(s), builtin.blake2b_256(int_to_bytearray(s.seed))) }
+}
+
+pub fn bytearray_fixed(len: Int) -> Fuzzer<ByteArray> {
+  if len <= 0 {
+    constant("")
+  } else {
+    do_bytearray(len, constant(""))
+  }
+}
+
+fn do_bytearray(len: Int, tail: Fuzzer<ByteArray>) -> Fuzzer<ByteArray> {
+  if len <= 32 {
+    let head = map(bytearray.take(_, len), bytearray())
+    map2(bytearray.concat, head, tail)
+  } else {
+    let head = bytearray()
+    do_bytearray(len - 32, map2(bytearray.concat, head, tail))
+  }
+}
+
+pub fn map2(f: fn(a, b) -> c, fuzz_a: Fuzzer<a>, fuzz_b: Fuzzer<b>) -> Fuzzer<c> {
+  fn(x) { f(x, _) }
+    |> map(fuzz_a)
+    |> and_map(fuzz_b)
+}
+
+// Internal
+
+fn step_seed(s: Seed) -> Seed {
+  let Seed { size, seed } = s
+  Seed { size, seed: step_pos_int(seed) }
+}
+
+fn step_pos_int(x: Int) -> Int {
+  bytearray_to_int(builtin.blake2b_256(int_to_bytearray(x)))
+}
+
+fn int_to_bytearray(x: Int) -> ByteArray {
+  if x == 0 {
+    ""
+  } else {
+    bytearray.push(int_to_bytearray(x / 256), x % 256)
+  }
+}
+
+fn bytearray_to_int(x: ByteArray) -> Int {
+  if bytearray.length(x) == 0 {
+    0
+  } else {
+    powsum(x, bytearray.length(x) - 1)
+  }
+}
+
+fn powsum(x: ByteArray, ix: Int) {
+  // UNSAFE : For empty bytearray
+  if ix <= 0 {
+    builtin.index_bytearray(x, ix)
+  } else {
+    pow2(8 * ix) * builtin.index_bytearray(x, ix) + powsum(x, ix - 1)
+  }
+}

--- a/lib/fuzz/types.ak
+++ b/lib/fuzz/types.ak
@@ -1,4 +1,3 @@
-
 pub type Seed {
   size: Int,
   seed: Int,
@@ -6,4 +5,3 @@ pub type Seed {
 
 pub type Fuzz<a> =
   fn(Seed) -> (a, Seed)
-


### PR DESCRIPTION
  With the following rationale:

  - We try to not expose the seed outside of the API, because its management is cumbersome and a good footgun (one shouldn't reuse a seed once it has served to generate a value).

  - To avoid also making the writing of the library too cumbersome, we also want to limit seed management internally as much as possible so we came up with a minimal set of primitives "allowed" to manipulate the seed. Any other primitives from the API should rely on this initial set to ensure proper manipulation of the seed(s).